### PR TITLE
Fix wrong status code when PDF is missing

### DIFF
--- a/src/modules/ServiceOrderPdf/serviceOrderPdf.controller.js
+++ b/src/modules/ServiceOrderPdf/serviceOrderPdf.controller.js
@@ -7,7 +7,7 @@ export default ({ getSanitizedServiceOrderData, getPrintableData, serviceOrderSe
       },
     });
 
-    if (!serviceOrderDataRaw) return res.send(404);
+    if (!serviceOrderDataRaw) return res.sendStatus(404);
 
     const [customerCarData, serviceItems] = await getPrintableData(serviceOrderDataRaw);
     const serviceOrderData = getSanitizedServiceOrderData(serviceOrderDataRaw);


### PR DESCRIPTION
## Summary
- fix PDF route to send a proper 404 status

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68430a1dbb44832ca888bc702647c1bf