### PR TITLE
Add image-based service order automation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,4 @@ PORTAL_USERNAME=admin
 PORTAL_PASSWORD=abcd
 DATABASE_URL=mysql://127.0.0.1:3307/engine?user=root
 PUPPETEER_EXECUTABLE_PATH=/usr/bin/google-chrome
+OPENAI_API_KEY=

--- a/src/index.routes.js
+++ b/src/index.routes.js
@@ -6,6 +6,7 @@ import customerRoutes from './modules/Customer/customer.routes';
 import customerCarRoutes from './modules/CustomerCar/customer_car.routes';
 import serviceOrderRoutes from './modules/ServiceOrder/service_order.routes';
 import serviceOrderPdfRoutes from './modules/ServiceOrderPdf/serviceOrderPdf.routes';
+import imageOrderRoutes from './modules/ImageOrder/image_order.routes';
 
 require('dotenv').config();
 
@@ -18,5 +19,10 @@ router.use('/customers', jwt({ secret: SECRET, algorithms: ['HS256'] }), custome
 router.use('/customer_cars', jwt({ secret: SECRET, algorithms: ['HS256'] }), customerCarRoutes);
 router.use('/service_orders', jwt({ secret: SECRET, algorithms: ['HS256'] }), serviceOrderRoutes);
 router.use('/service_orders_pdf', serviceOrderPdfRoutes);
+router.use(
+  '/service_order_images',
+  jwt({ secret: SECRET, algorithms: ['HS256'] }),
+  imageOrderRoutes
+);
 
 export default router;

--- a/src/modules/ImageOrder/image_order.controller.js
+++ b/src/modules/ImageOrder/image_order.controller.js
@@ -1,0 +1,11 @@
+export default ({ service }) => ({
+  async create(req, res, next) {
+    try {
+      const { image } = req.body;
+      const result = await service.processImage(image);
+      res.status(200).json(result);
+    } catch (e) {
+      next(e);
+    }
+  },
+});

--- a/src/modules/ImageOrder/image_order.routes.js
+++ b/src/modules/ImageOrder/image_order.routes.js
@@ -1,0 +1,29 @@
+import express from 'express';
+import makeCRUDService from '../../services/makeCRUDService';
+import makeCustomerCarService from '../../services/customerCarService';
+import makeServiceOrderService from '../../services/serviceOrderService';
+import makeServiceOrderItemsService from '../../services/serviceOrderItemsService';
+import { queryService } from '../../services/databaseService/queryService';
+import queryBuilder from '../../services/databaseService/dbOperations/queryBuilder';
+import makeOpenAIVisionService from '../../services/openai/openAIVisionService';
+import makeProcessImageService from '../../services/openai/serviceOrderFromImageService';
+import makeController from './image_order.controller';
+
+const router = express.Router();
+
+const customerCarCRUD = makeCRUDService({ queryService, resourceName: 'customer_cars' });
+const serviceOrderCRUD = makeCRUDService({ queryService, resourceName: 'service_orders' });
+const serviceOrderItemsCRUD = makeCRUDService({ queryService, resourceName: 'service_order_items' });
+
+const service = makeProcessImageService({
+  openAIVisionService: makeOpenAIVisionService({ openAIKey: process.env.OPENAI_API_KEY }),
+  customerCarService: makeCustomerCarService({ CRUDService: customerCarCRUD }),
+  serviceOrderService: makeServiceOrderService({ commonService: serviceOrderCRUD, queryService, queryBuilder }),
+  serviceOrderItemsService: makeServiceOrderItemsService({ commonService: serviceOrderItemsCRUD, queryService, queryBuilder }),
+});
+
+const controller = makeController({ service });
+
+router.post('/', controller.create);
+
+export default router;

--- a/src/services/openai/__tests__/openAIVisionService.test.js
+++ b/src/services/openai/__tests__/openAIVisionService.test.js
@@ -1,0 +1,16 @@
+import makeOpenAIVisionService from '../openAIVisionService';
+
+describe('openAIVisionService', () => {
+  it('should parse JSON content from API response', async () => {
+    const fetchFn = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: '{"license_plate":"AAA1234"}' } }],
+      }),
+    });
+
+    const service = makeOpenAIVisionService({ openAIKey: 'key', fetchFn });
+    const result = await service.parseImage('image');
+    expect(result).toEqual({ license_plate: 'AAA1234' });
+  });
+});

--- a/src/services/openai/openAIVisionService.js
+++ b/src/services/openai/openAIVisionService.js
@@ -1,0 +1,47 @@
+export const makeOpenAIVisionService = ({ openAIKey, fetchFn = fetch } = {}) => ({
+  async parseImage(base64Image) {
+    const body = {
+      model: 'gpt-4-vision-preview',
+      messages: [
+        {
+          role: 'system',
+          content:
+            'You extract car license plates and a list of service items from images. Return JSON like {"license_plate":"ABC1234","items":[{"description":"part","quantity":1,"unit_price":10}]}',
+        },
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'Read the image and return the license plate and parts with quantity and unit price in JSON.' },
+            { type: 'image_url', image_url: `data:image/jpeg;base64,${base64Image}` },
+          ],
+        },
+      ],
+      temperature: 0,
+    };
+
+    const response = await fetchFn('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${openAIKey}`,
+      },
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      const error = new Error('OPENAI_REQUEST_FAILED');
+      error.status = response.status;
+      throw error;
+    }
+
+    const data = await response.json();
+    const content = data.choices?.[0]?.message?.content || '{}';
+    try {
+      return JSON.parse(content);
+    } catch (e) {
+      return { raw: content };
+    }
+  },
+});
+
+export default makeOpenAIVisionService;

--- a/src/services/openai/serviceOrderFromImageService.js
+++ b/src/services/openai/serviceOrderFromImageService.js
@@ -1,0 +1,54 @@
+export default ({
+  openAIVisionService,
+  customerCarService,
+  serviceOrderService,
+  serviceOrderItemsService,
+} = {}) => ({
+  async processImage(base64Image) {
+    const parsed = await openAIVisionService.parseImage(base64Image);
+    const { license_plate: licensePlate, items = [] } = parsed;
+
+    if (!licensePlate) {
+      const error = new Error('LICENSE_PLATE_NOT_FOUND');
+      error.code = 'LICENSE_PLATE_NOT_FOUND';
+      throw error;
+    }
+
+    const [customerCar] = await customerCarService.getList({
+      limit: 1,
+      q: { license_plate: licensePlate },
+    });
+    if (!customerCar) {
+      const error = new Error('CAR_NOT_FOUND');
+      error.code = 'CAR_NOT_FOUND';
+      throw error;
+    }
+
+    const [serviceOrder] = await serviceOrderService.getList({
+      limit: 1,
+      resourcesJoinIds: { customer_car_id: customerCar.id },
+      customQueryBuilderOperation: (qb) => qb.orderBy('service_orders.created_at', 'desc'),
+    });
+    if (!serviceOrder) {
+      const error = new Error('SERVICE_ORDER_NOT_FOUND');
+      error.code = 'SERVICE_ORDER_NOT_FOUND';
+      throw error;
+    }
+
+    const createdItems = [];
+    for (const item of items) {
+      const { description, quantity, unit_price } = item;
+      if (!description) continue;
+      const newItem = await serviceOrderItemsService.insert({
+        service_order_id: serviceOrder.id,
+        description,
+        quantity: quantity || 1,
+        unit_price: unit_price || 0,
+        service_items_price: quantity && unit_price ? quantity * unit_price : 0,
+      });
+      createdItems.push(newItem);
+    }
+
+    return { serviceOrder, items: createdItems };
+  },
+});


### PR DESCRIPTION
## Summary
- fix env file formatting and add OPENAI_API_KEY variable
- enable processing service orders from images
- hook new route into the API
- basic tests for OpenAI vision parsing

## Testing
- `npm install --silent` *(fails: network restricted)*
- `npm test --silent` *(fails: jest not found)*


------
https://chatgpt.com/codex/tasks/task_e_6862f6650b40832c9688cdaf6bbd7f5e